### PR TITLE
Avoid recursive calls to `reload_bert`

### DIFF
--- a/test/bert_loader_SUITE.erl
+++ b/test/bert_loader_SUITE.erl
@@ -74,7 +74,7 @@ observe_changes(Config) ->
     file:write_file(File, term_to_binary(NewList)),
     lib_SUITE:bump_time(File),
     %% wait for reload
-    timer:sleep(750),
+    timer:sleep(1200),
     [#tab{id=Format2}] = ets:lookup(?TABLE, format),
     true = Format1 =/= Format2,
     [#tab{}] = ets:lookup(?TABLE, newtable),
@@ -86,5 +86,5 @@ observe_changes(Config) ->
     %% force a reload
     file:write_file(File, term_to_binary(NewList)),
     lib_SUITE:bump_time(File),
-    timer:sleep(750),
+    timer:sleep(1200),
     undefined = ets:info(Format1).

--- a/test/bertconf_SUITE.erl
+++ b/test/bertconf_SUITE.erl
@@ -69,7 +69,7 @@ table_version(Config) ->
     lib_SUITE:bump_time(File),
 
     %% wait for reload
-    timer:sleep(950),
+    timer:sleep(1200),
 
     old = bertconf:version(format, Version),
     NewVersion = bertconf:version(format),


### PR DESCRIPTION
The non-tail recursive calls to `reload_bert` can lead to huge memory usage. The proposed solution is to keep the old timer mechanism where the `dirwatch` messages will set a flag which will be checked periodically for reloads.

Note that this will change the dirwatch cooldown to zero since the periodic timer already acts as a builtin cooldown-ish.

https://github.com/tokenrove/bertconf/issues/2

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenrove/bertconf/3)

<!-- Reviewable:end -->
