### PR TITLE
Ensure that reload_bert is tail recursive

### DIFF
--- a/src/bertconf_bert_loader.erl
+++ b/src/bertconf_bert_loader.erl
@@ -75,11 +75,29 @@ reload_bert(OldChanges) ->
     NewTables = store(merge(lists:sort(lists:flatten(Terms)))),
     OldTables = update_table_index(NewTables),
     NewChanges = lists:append([Refs || {_, Refs} <- Changes]),
-    receive needs_reload ->
-            reload_bert(Changes)
-    after 0 -> ok
-    end,
-    ?MODULE ! {reloaded, OldTables, NewChanges}.
+    ?MODULE ! {reloaded, OldTables, NewChanges},
+
+    %% This MUST be tail-recursive otherwise we could end up with
+    %% multiple versions of large bertconf tables loaded in memory
+    %% which can easily trigger out-of-memory errors.
+    case reload_more() of
+        reload -> reload_bert(Changes);
+        stop -> ok
+    end.
+
+reload_more() ->
+    reload_more(stop).
+
+%% dequeue all the pending messages to avoid doing a bunch of
+%% pointless reloads (has been observed in prod).
+reload_more(Result) ->
+    receive
+        needs_reload -> reload_more(reload)
+    after
+        0 -> Result
+    end.
+
+
 
 reload_bert_file(File) ->
     case file:read_file(File) of


### PR DESCRIPTION
To unblock the fix, I created the tail recursive version and documented the potential race condition that could happen. I also tweaked the message processing to avoid doing pointless reloads. Note that I have no hard evidence that we ever have more then one needs_reload message in that queue.

Note that upon closer inspection, the race-condition that I was worried in https://github.com/tokenrove/bertconf/pull/3, is unlikely to be triggered in production so the tail-recursive version should do just fine.
